### PR TITLE
[feat]: improve dashboard statistics

### DIFF
--- a/Apps/NuGetStatsApp.cs
+++ b/Apps/NuGetStatsApp.cs
@@ -327,9 +327,9 @@ public class IvyInsightsApp : ViewBase
             | new Card(
                 Layout.Vertical().Gap(2).Padding(3).Align(Align.Center)
                     | Text.H2(animatedVersions.Value.ToString("N0")).Bold()
-                    | (versionsThisMonth > 0
-                        ? Text.Block($"+{versionsThisMonth} this month").Muted()
-                        : null)
+                    | Text.Block(versionsThisMonth > 0
+                        ? $"+{versionsThisMonth} this month"
+                        : "0 versions released this month").Muted()
             ).Title("Total Versions").Icon(Icons.Tag)
             | new Card(
                 Layout.Vertical().Gap(2).Padding(3).Align(Align.Center)


### PR DESCRIPTION
# Enhance Statistics Display

## Summary
This PR improves the statistics dashboard by extending the GitHub Stars display period and enhancing user feedback for the versions card.

## Changes

### 1. Extended GitHub Stars Display Period
- **Changed**: GitHub Stars chart now displays data for the last **365 days** instead of 30 days
- **Impact**: Users can now see a full year of GitHub stars history, providing better long-term trend visibility
- **Files Modified**: `Apps/NuGetStatsApp.cs`
  - Updated `GetGithubStarsStatsAsync` call from 30 to 365 days
  - Updated card title from "GitHub Stars (Last 30 Days)" to "GitHub Stars (Last 365 Days)"

### 2. Improved Versions Display Feedback
- **Changed**: "Total Versions" card now always displays monthly version information, even when no versions were released
- **Before**: Card showed nothing when `versionsThisMonth = 0`
- **After**: Card displays "0 versions released this month" when no versions were released in the current month
- **Impact**: Better user experience - users always see feedback about monthly version activity
- **Files Modified**: `Apps/NuGetStatsApp.cs`
  - Changed conditional rendering to always show version count message

<img width="1284" height="807" alt="image" src="https://github.com/user-attachments/assets/31c5f728-6a01-4757-b651-667097eeea87" />
