### PR TITLE
feat: add OpenAPI spec UI and Scalar documentation

### DIFF
--- a/Apps/NuGetStatsApp.cs
+++ b/Apps/NuGetStatsApp.cs
@@ -860,6 +860,12 @@ public class IvyInsightsApp : ViewBase
             ).Width(Size.Rem(28));
         }
 
+        var openApiButton = new Button("OpenAPI spec")
+            .Icon(Icons.FileCode)
+            .Variant(ButtonVariant.Outline)
+            .Large()
+            .HandleClick(_ => navigator.Navigate("/scalar"));
+
         return Layout.Vertical().Align(Align.TopCenter)
             | metrics.Width(Size.Fraction(0.9f))
             | (Layout.Grid().Columns(3).Width(Size.Fraction(0.9f))
@@ -869,10 +875,11 @@ public class IvyInsightsApp : ViewBase
             | (Layout.Horizontal().Width(Size.Fraction(0.9f)).Height(Size.Units(140))
                 | versionChartCard
                 | totalDownloadsCard)
+            | versionsTableCard
+            | new FloatingPanel(openApiButton, Align.BottomRight).Offset(new Thickness(0, 0, 10, 5))
             | ( Layout.Horizontal().Width(Size.Fraction(0.9f)).Height(Size.Units(140))
                 | githubStarsCard
                 | stargazersDailyCard )
-            | versionsTableCard
             | stargazersTodayDialog
             | stargazerDetailDialog;
     }

--- a/Apps/NuGetStatsApp.cs
+++ b/Apps/NuGetStatsApp.cs
@@ -864,7 +864,7 @@ public class IvyInsightsApp : ViewBase
             .Icon(Icons.FileCode)
             .Variant(ButtonVariant.Outline)
             .Large()
-            .HandleClick(_ => navigator.Navigate("/scalar"));
+            .Url("/scalar");
 
         return Layout.Vertical().Align(Align.TopCenter)
             | metrics.Width(Size.Fraction(0.9f))

--- a/IvyInsights.csproj
+++ b/IvyInsights.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
     <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
     <RootNamespace>IvyInsights</RootNamespace>
     <UserSecretsId>e8bb724a-3b0b-42dd-8b9d-01725b8695cf</UserSecretsId>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,10 +16,11 @@
   </ItemGroup>
 
   
-    <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.14-pre-20260213104724" />
-      <PackageReference Include="Npgsql" Version="9.0.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Ivy" Version="1.2.15" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />
+  </ItemGroup>
     
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Exposes the IvyInsights Web API via OpenAPI and Scalar UI, and adds a floating button in the app to open the API documentation.

https://github.com/user-attachments/assets/1a3ce0ac-d480-49a1-8b34-652806e0cbb2


## Changes
- **OpenAPI + Scalar**: Register OpenAPI document, map `/openapi` and Scalar UI at `/scalar`
- **Document filter**: Restrict OpenAPI doc to IvyInsights endpoints only (paths and tags), so Scalar shows a single "IvyInsights" section
- **Floating button**: Add "OpenAPI spec" button in a `FloatingPanel` (bottom-right) with `.Url("/scalar")` for navigation to the docs
- **Dependencies**: Add `Scalar.AspNetCore` and `InterceptorsNamespaces` for OpenAPI source generators

## Result
- API docs available at `/scalar`
- One-tap access from the Ivy Insights app via the floating button
- Only IvyInsights endpoints (e.g. `/starred`, `/stars`, `/downloads`, `/summary`) appear in the docs